### PR TITLE
Add adjustable reconnects and settings revisions

### DIFF
--- a/ntfysh_client/SettingsDialog.Designer.cs
+++ b/ntfysh_client/SettingsDialog.Designer.cs
@@ -29,101 +29,147 @@ namespace ntfysh_client
         /// </summary>
         private void InitializeComponent()
         {
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.cancelButton = new System.Windows.Forms.Button();
-            this.saveButton = new System.Windows.Forms.Button();
-            this.label1 = new System.Windows.Forms.Label();
-            this.timeout = new System.Windows.Forms.NumericUpDown();
-            this.panel1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.timeout)).BeginInit();
-            this.SuspendLayout();
+            buttonPanel = new System.Windows.Forms.Panel();
+            cancelButton = new System.Windows.Forms.Button();
+            saveButton = new System.Windows.Forms.Button();
+            timeoutLabel = new System.Windows.Forms.Label();
+            timeout = new System.Windows.Forms.NumericUpDown();
+            reconnectAttempts = new System.Windows.Forms.NumericUpDown();
+            reconnectAttemptsLabel = new System.Windows.Forms.Label();
+            reconnectAttemptDelay = new System.Windows.Forms.NumericUpDown();
+            reconnectAttemptDelayLabel = new System.Windows.Forms.Label();
+            buttonPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)timeout).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)reconnectAttempts).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)reconnectAttemptDelay).BeginInit();
+            SuspendLayout();
             // 
-            // panel1
+            // buttonPanel
             // 
-            this.panel1.BackColor = System.Drawing.SystemColors.Control;
-            this.panel1.Controls.Add(this.cancelButton);
-            this.panel1.Controls.Add(this.saveButton);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel1.Location = new System.Drawing.Point(0, 61);
-            this.panel1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(531, 51);
-            this.panel1.TabIndex = 9;
+            buttonPanel.BackColor = System.Drawing.SystemColors.Control;
+            buttonPanel.Controls.Add(cancelButton);
+            buttonPanel.Controls.Add(saveButton);
+            buttonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            buttonPanel.Location = new System.Drawing.Point(0, 150);
+            buttonPanel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            buttonPanel.Name = "buttonPanel";
+            buttonPanel.Size = new System.Drawing.Size(531, 51);
+            buttonPanel.TabIndex = 0;
             // 
             // cancelButton
             // 
-            this.cancelButton.Location = new System.Drawing.Point(363, 16);
-            this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(75, 23);
-            this.cancelButton.TabIndex = 1;
-            this.cancelButton.Text = "Cancel";
-            this.cancelButton.UseVisualStyleBackColor = true;
-            this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
+            cancelButton.Location = new System.Drawing.Point(363, 16);
+            cancelButton.Name = "cancelButton";
+            cancelButton.Size = new System.Drawing.Size(75, 23);
+            cancelButton.TabIndex = 2;
+            cancelButton.Text = "Cancel";
+            cancelButton.UseVisualStyleBackColor = true;
+            cancelButton.Click += cancelButton_Click;
             // 
             // saveButton
             // 
-            this.saveButton.Location = new System.Drawing.Point(444, 16);
-            this.saveButton.Name = "saveButton";
-            this.saveButton.Size = new System.Drawing.Size(75, 23);
-            this.saveButton.TabIndex = 0;
-            this.saveButton.Text = "Save";
-            this.saveButton.UseVisualStyleBackColor = true;
-            this.saveButton.Click += new System.EventHandler(this.saveButton_Click);
+            saveButton.Location = new System.Drawing.Point(444, 16);
+            saveButton.Name = "saveButton";
+            saveButton.Size = new System.Drawing.Size(75, 23);
+            saveButton.TabIndex = 1;
+            saveButton.Text = "Save";
+            saveButton.UseVisualStyleBackColor = true;
+            saveButton.Click += saveButton_Click;
             // 
-            // label1
+            // timeoutLabel
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(13, 9);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(488, 15);
-            this.label1.TabIndex = 11;
-            this.label1.Text = "Notification Toast Timeout (seconds, may be ignored by OS based on accessibility " +
-    "settings):";
+            timeoutLabel.AutoSize = true;
+            timeoutLabel.Location = new System.Drawing.Point(13, 9);
+            timeoutLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            timeoutLabel.Name = "timeoutLabel";
+            timeoutLabel.Size = new System.Drawing.Size(488, 15);
+            timeoutLabel.TabIndex = 3;
+            timeoutLabel.Text = "Notification Toast Timeout (seconds, may be ignored by OS based on accessibility settings):";
             // 
             // timeout
             // 
-            this.timeout.Location = new System.Drawing.Point(13, 27);
-            this.timeout.Maximum = new decimal(new int[] {
-            -1981284353,
-            -1966660860,
-            0,
-            0});
-            this.timeout.Name = "timeout";
-            this.timeout.Size = new System.Drawing.Size(506, 23);
-            this.timeout.TabIndex = 12;
+            timeout.Location = new System.Drawing.Point(13, 28);
+            timeout.Maximum = new decimal(new int[] { -1981284353, -1966660860, 0, 0 });
+            timeout.Name = "timeout";
+            timeout.Size = new System.Drawing.Size(506, 23);
+            timeout.TabIndex = 4;
+            // 
+            // reconnectAttempts
+            // 
+            reconnectAttempts.Location = new System.Drawing.Point(12, 73);
+            reconnectAttempts.Maximum = new decimal(new int[] { -1981284353, -1966660860, 0, 0 });
+            reconnectAttempts.Name = "reconnectAttempts";
+            reconnectAttempts.Size = new System.Drawing.Size(506, 23);
+            reconnectAttempts.TabIndex = 6;
+            // 
+            // reconnectAttemptsLabel
+            // 
+            reconnectAttemptsLabel.AutoSize = true;
+            reconnectAttemptsLabel.Location = new System.Drawing.Point(12, 54);
+            reconnectAttemptsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            reconnectAttemptsLabel.Name = "reconnectAttemptsLabel";
+            reconnectAttemptsLabel.Size = new System.Drawing.Size(198, 15);
+            reconnectAttemptsLabel.TabIndex = 5;
+            reconnectAttemptsLabel.Text = "Maximum reconnect retry attempts (requires restart):";
+            // 
+            // reconnectAttemptDelay
+            // 
+            reconnectAttemptDelay.Location = new System.Drawing.Point(12, 118);
+            reconnectAttemptDelay.Maximum = new decimal(new int[] { -1981284353, -1966660860, 0, 0 });
+            reconnectAttemptDelay.Name = "reconnectAttemptDelay";
+            reconnectAttemptDelay.Size = new System.Drawing.Size(506, 23);
+            reconnectAttemptDelay.TabIndex = 8;
+            // 
+            // reconnectAttemptDelayLabel
+            // 
+            reconnectAttemptDelayLabel.AutoSize = true;
+            reconnectAttemptDelayLabel.Location = new System.Drawing.Point(12, 99);
+            reconnectAttemptDelayLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            reconnectAttemptDelayLabel.Name = "reconnectAttemptDelayLabel";
+            reconnectAttemptDelayLabel.Size = new System.Drawing.Size(191, 15);
+            reconnectAttemptDelayLabel.TabIndex = 7;
+            reconnectAttemptDelayLabel.Text = "Delay between attempts (seconds, requires restart):";
             // 
             // SettingsDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(531, 112);
-            this.Controls.Add(this.timeout);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.panel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "SettingsDialog";
-            this.ShowIcon = false;
-            this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Settings";
-            this.panel1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.timeout)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            BackColor = System.Drawing.Color.White;
+            ClientSize = new System.Drawing.Size(531, 201);
+            Controls.Add(reconnectAttemptDelay);
+            Controls.Add(reconnectAttemptDelayLabel);
+            Controls.Add(reconnectAttempts);
+            Controls.Add(reconnectAttemptsLabel);
+            Controls.Add(timeout);
+            Controls.Add(timeoutLabel);
+            Controls.Add(buttonPanel);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "SettingsDialog";
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "Settings";
+            buttonPanel.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)timeout).EndInit();
+            ((System.ComponentModel.ISupportInitialize)reconnectAttempts).EndInit();
+            ((System.ComponentModel.ISupportInitialize)reconnectAttemptDelay).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
 
-        private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Panel buttonPanel;
+        private System.Windows.Forms.Label timeoutLabel;
         private System.Windows.Forms.NumericUpDown timeout;
         private System.Windows.Forms.Button cancelButton;
         private System.Windows.Forms.Button saveButton;
+        private System.Windows.Forms.NumericUpDown reconnectAttempts;
+        private System.Windows.Forms.Label reconnectAttemptsLabel;
+        private System.Windows.Forms.NumericUpDown reconnectAttemptDelay;
+        private System.Windows.Forms.Label reconnectAttemptDelayLabel;
     }
 }

--- a/ntfysh_client/SettingsDialog.cs
+++ b/ntfysh_client/SettingsDialog.cs
@@ -11,6 +11,18 @@ namespace ntfysh_client
             set => timeout.Value = value;
         }
 
+        public decimal ReconnectAttempts
+        {
+            get => reconnectAttempts.Value;
+            set => reconnectAttempts.Value = value;
+        }
+
+        public decimal ReconnectAttemptDelay
+        {
+            get => reconnectAttemptDelay.Value;
+            set => reconnectAttemptDelay.Value = value;
+        }
+
         public SettingsDialog()
         {
             InitializeComponent();

--- a/ntfysh_client/SettingsDialog.resx
+++ b/ntfysh_client/SettingsDialog.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/ntfysh_client/SettingsModel.cs
+++ b/ntfysh_client/SettingsModel.cs
@@ -2,6 +2,9 @@
 {
     public class SettingsModel
     {
+        public uint Revision { get; set; }
         public decimal Timeout { get; set; }
+        public decimal ReconnectAttempts { get; set; }
+        public decimal ReconnectAttemptDelay { get; set; }
     }
 }


### PR DESCRIPTION
# What I have done
- Allowed changing the reconnect attempt count and delay based on discussed fix #10 
- Settings window tab indexing cleaned up
- Settings window element names cleaned up
- Added a revision property to the settings to update settings files with new values safely and correctly populate new defaults
- Throw correct ArgumentExceptions in palce of InvalidOperationExceptions
- Rearranged signatures containing CancellationTokens to be consistent with MS's uses, including with `default` assignment
- Code comment typos

# Testing
Here is a published release which you can post in the Releases section after merging the PR if you'd like:
[ntfy.sh Release.zip](https://github.com/lucas-bortoli/ntfysh-windows/files/12850290/ntfy.sh.Release.zip)
